### PR TITLE
Add environment to install GitHub binary using Ansible

### DIFF
--- a/ansible/extract-gh-archive/README.md
+++ b/ansible/extract-gh-archive/README.md
@@ -1,0 +1,33 @@
+# Extracting and "Installing" Something from GitHub
+
+These files provide an example of how to download, extract, and "install" a binary release of an open source project from GitHub. As an example, the playbook shows how to do this for `ksonnet`, a Kubernetes-related open source project led by Heptio.
+
+## Contents
+
+* **machines.yml**: This YAML data file is used by Vagrant to determine which VM images to use, how many VMs to create, and what the configuration of those VMs should be.
+
+* **provision.yml**: This Ansible playbook shows creating a temporary directory, registering that temporary directory for later use, then downloading, extracting, and "installing" a binary release.
+
+* **README.md**: The file you're currently reading.
+
+* **Vagrantfile**: This file is used by Vagrant to spin up VMs. No changes should be needed to this file; all configuration information is provided in `machines.yml`.
+
+## Instructions
+
+These instructions assume that you have both Vagrant and Ansible installed and functioning correctly on your system, and that the virtualization provider used by Vagrant is working as expected. These instructions also assume that you've installed any necessary Vagrant plugins to support the installed virtualization provider.
+
+1. Place the files from the `ansible/extract-gh-archive` directory of this GitHub repository into a directory on your local system. You can clone the entire "learning-tools" repository (using `git clone`) or just download the specific files from the `ansible/extract-gh-archive` folder.
+
+2. Install a Vagrant box for CentOS 7. The `machines.yml` file contains suggested boxes for VirtualBox, VMware, and Libvirt.
+
+3. Run `vagrant up` to spin up the Vagrant VM. Vagrant will automatically invoke Ansible. Ansible will create a temporary directory, download the latest (as of this writing) `ksonnet` release archive into that directory, extract it, and copy out the `ks` binary to a versioned copy.
+
+4. Use `vagrant ssh` to log into the Vagrant VM and see that `ks` is installed and in the path. Press Ctrl-D to log out when you're finished.
+
+5. Run `vagrant destroy` to tear down the environment.
+
+Enjoy!
+
+## License
+
+This content is licensed under the MIT License.

--- a/ansible/extract-gh-archive/Vagrantfile
+++ b/ansible/extract-gh-archive/Vagrantfile
@@ -1,0 +1,81 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Specify minimum Vagrant version and Vagrant API version
+Vagrant.require_version '>= 1.6.0'
+VAGRANTFILE_API_VERSION = '2'
+
+# Require 'yaml' module
+require 'yaml'
+
+# Read YAML file with VM details (box, CPU, and RAM)
+machines = YAML.load_file(File.join(File.dirname(__FILE__), 'machines.yml'))
+
+# Create and configure the VMs
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+
+  # Always use Vagrant's default insecure key
+  config.ssh.insert_key = false
+
+  # Iterate through entries in YAML file to create VMs
+  machines.each do |machine|
+    config.vm.define machine['name'] do |srv|
+
+      # Don't check for box updates
+      srv.vm.box_check_update = false
+      srv.vm.hostname = machine['name']
+
+      # Use VMware box by default
+      srv.vm.box = machine['box']['vmw']
+
+      # Configure default synced folder (disable by default)
+      if machine['sync_disabled'] != nil
+        srv.vm.synced_folder '.', '/vagrant', disabled: machine['sync_disabled']
+      else
+        srv.vm.synced_folder '.', '/vagrant', disabled: true
+      end #if machine['sync_disabled']
+
+      # Iterate through networks as per settings in machines.yml
+      machine['nics'].each do |net|
+        if net['ip_addr'] == 'dhcp'
+          srv.vm.network net['type'], type: net['ip_addr']
+        else
+          srv.vm.network net['type'], ip: net['ip_addr']
+        end # if net['ip_addr']
+      end # machine['nics'].each
+
+      # Configure CPU & RAM per settings in machines.yml (Fusion)
+      srv.vm.provider 'vmware_fusion' do |vmw|
+        vmw.vmx['memsize'] = machine['ram']
+        vmw.vmx['numvcpus'] = machine['vcpu']
+        if machine['nested'] == true
+          vmw.vmx['vhv.enable'] = 'TRUE'
+        end #if machine['nested']
+      end # srv.vm.provider 'vmware_fusion'
+
+      # Configure CPU & RAM per settings in machines.yml (VirtualBox)
+      srv.vm.provider 'virtualbox' do |vb, override|
+        vb.memory = machine['ram']
+        vb.cpus = machine['vcpu']
+        override.vm.box = machine['box']['vb']
+        vb.customize ['modifyvm', :id, '--nictype1', 'virtio']
+        vb.customize ['modifyvm', :id, '--nictype2', 'virtio']
+      end # srv.vm.provider 'virtualbox'
+
+      # Configure CPU & RAM per settings in machines.yml (Libvirt)
+      srv.vm.provider 'libvirt' do |lv, override|
+        lv.memory = machine['ram']
+        lv.cpus = machine['vcpu']
+        override.vm.box = machine['box']['lv']
+        if machine['nested'] == true
+          lv.nested = true
+        end # if machine['nested']
+      end # srv.vm.provider 'libvirt'
+    end # config.vm.define
+
+    # Provision the VM with Ansible
+    config.vm.provision 'ansible' do |ansible|
+      ansible.playbook = 'provision.yml'
+    end # config.vm.provision
+  end # machines.each
+end # Vagrant.configure

--- a/ansible/extract-gh-archive/machines.yml
+++ b/ansible/extract-gh-archive/machines.yml
@@ -1,0 +1,13 @@
+---
+- box:
+    vmw: "bento/centos-7.1"
+    vb: "centos/7"
+    lv: "centos/7"
+  name: "centos-01"
+  nested: false
+  nics:
+    - type: "private_network"
+      ip_addr: "dhcp"
+  ram: "512"
+  sync_disabled: true
+  vcpu: "1"

--- a/ansible/extract-gh-archive/provision.yml
+++ b/ansible/extract-gh-archive/provision.yml
@@ -1,0 +1,50 @@
+---
+- hosts: "all"
+  vars:
+    github: "https://github.com"
+  become: "yes"
+  remote_user: "vagrant"
+
+  tasks:
+  - name: Ensure /usr/local/bin directory exists
+    file:
+      state: "directory"
+      path: "/usr/local/bin"
+      owner: "root"
+      group: "root"
+
+  - name: Create a temporary directory
+    tempfile:
+      state: "directory"
+      suffix: "tmp"
+    register: "tmpdir"
+
+  - name: Download and extract ksonnet archive from GitHub
+    unarchive:
+      src: "{{ github }}/ksonnet/ksonnet/releases/download/v0.10.2/ks_0.10.2_linux_amd64.tar.gz"
+      dest: "{{ tmpdir.path }}"
+      remote_src: "yes"
+      owner: "root"
+      group: "root"
+
+  - name: Copy versioned ks binary into final location
+    copy:
+      src: "{{ tmpdir.path }}/ks_0.10.2_linux_amd64/ks"
+      dest: "/usr/local/bin/ks-0.10.2"
+      remote_src: "yes"
+      owner: "root"
+      group: "root"
+      mode: 0755
+
+  - name: Make a symbolic link to versioned binary
+    file:
+      path: "/usr/local/bin/ks"
+      src: "/usr/local/bin/ks-0.10.2"
+      state: "link"
+      owner: "root"
+      group: "root"
+
+  - name: Remove temporary directory
+    file:
+      path: "{{ tmpdir.path }}"
+      state: "absent"


### PR DESCRIPTION
Add Ansible+Vagrant environment to demonstrate using Ansible to download a binary release from GitHub, extract it, and copy out the relevant binary into the path. Not terribly unusual or unique, but shows a few techniques that early Ansible users may not know.
