### PR TITLE
Add Terraform configuration for working with Oracle Cloud

### DIFF
--- a/terraform/oci/data.tf
+++ b/terraform/oci/data.tf
@@ -1,0 +1,8 @@
+data "oci_identity_availability_domains" "oci_ads" {
+  compartment_id = "${var.oci_tenancy_ocid}"
+}
+
+data "oci_core_images" "oci_base_image" {
+  compartment_id = "${var.oci_tenancy_ocid}"
+  display_name   = "${var.oci_image_name}"
+}

--- a/terraform/oci/main.tf
+++ b/terraform/oci/main.tf
@@ -1,0 +1,56 @@
+resource "oci_core_vcn" "test_vcn" {
+  cidr_block = "10.18.0.0/16"
+  compartment_id = "${var.oci_tenancy_ocid}"
+  display_name = "test-vcn"
+  dns_label = "testvcn"
+}
+
+resource "oci_core_subnet" "test_subnet" {
+  availability_domain = "${lookup(data.oci_identity_availability_domains.oci_ads.availability_domains[0],"name")}"
+  cidr_block = "10.18.1.0/24"
+  compartment_id = "${var.oci_tenancy_ocid}"
+  vcn_id = "${oci_core_vcn.test_vcn.id}"
+  dns_label = "testsubnet"
+  route_table_id = "${oci_core_route_table.test_rt.id}"
+}
+
+resource "oci_core_internet_gateway" "test_ig" {
+  compartment_id = "${var.oci_tenancy_ocid}"
+  display_name = "test-ig"
+  vcn_id = "${oci_core_vcn.test_vcn.id}"
+}
+
+resource "oci_core_route_table" "test_rt" {
+  compartment_id = "${var.oci_tenancy_ocid}"
+  vcn_id = "${oci_core_vcn.test_vcn.id}"
+  display_name = "test-route-table"
+
+  route_rules {
+    destination = "0.0.0.0/0"
+    destination_type = "CIDR_BLOCK"
+    network_entity_id = "${oci_core_internet_gateway.test_ig.id}"
+  }
+}
+
+resource "oci_core_instance" "test" {
+  availability_domain = "${lookup(data.oci_identity_availability_domains.oci_ads.availability_domains[0],"name")}"
+  compartment_id      = "${var.oci_tenancy_ocid}"
+  display_name        = "test-instance"
+  shape               = "${var.oci_compute_shape}"
+
+  create_vnic_details {
+    subnet_id        = "${oci_core_subnet.test_subnet.id}"
+    display_name     = "primary_vnic"
+    assign_public_ip = true
+    hostname_label   = "test-instance"
+  }
+
+  source_details {
+    source_type = "image"
+    source_id   = "${data.oci_core_images.oci_base_image.images.0.id}"
+  }
+
+  metadata {
+    ssh_authorized_keys = "${file(var.ssh_key)}"
+  }
+}

--- a/terraform/oci/outputs.tf
+++ b/terraform/oci/outputs.tf
@@ -1,0 +1,3 @@
+output "instance_public_ip" {
+  value = "${oci_core_instance.test.public_ip}"
+}

--- a/terraform/oci/provider.tf
+++ b/terraform/oci/provider.tf
@@ -1,0 +1,8 @@
+provider "oci" {
+  version          = ">= 3.0.0"
+  region           = "${var.oci_region}"
+  tenancy_ocid     = "${var.oci_tenancy_ocid}"
+  user_ocid        = "${var.oci_user_ocid}"
+  fingerprint      = "${var.oci_fingerprint}"
+  private_key_path = "${var.oci_private_key_path}"
+}

--- a/terraform/oci/variables.tf
+++ b/terraform/oci/variables.tf
@@ -1,0 +1,41 @@
+variable "oci_region" {
+  description = "Region in which to create all resources"
+  type        = "string"
+  default     = "us-phoenix-1"
+}
+
+variable "oci_tenancy_ocid" {
+  description = "OCID for the tenant"
+  type        = "string"
+}
+
+variable "oci_user_ocid" {
+  description = "OCID for the user"
+  type        = "string"
+}
+
+variable "oci_fingerprint" {
+  description = "Fingerprint for API key"
+  type        = "string"
+}
+
+variable "oci_private_key_path" {
+  description = "Path to private key portion of API key"
+  type        = "string"
+}
+
+variable "oci_compute_shape" {
+  description = "Compute shape to use"
+  type        = "string"
+  default     = "VM.Standard1.1"
+}
+
+variable "oci_image_name" {
+  description = "Display name for image to use"
+  type = "string"
+}
+
+variable "ssh_key" {
+  description = "SSH key to use with instance(s)"
+  type = "string"
+}


### PR DESCRIPTION
This PR adds a sample Terraform configuration that shows how to use Terraform with Oracle Cloud Infrastructure (OCI) using the OCI provider.