### PR TITLE
Add Ansible role to create Pulumi environment

### DIFF
--- a/ansible/pulumi-env/README.md
+++ b/ansible/pulumi-env/README.md
@@ -1,0 +1,5 @@
+## Ansible Role for a Pulumi Environment
+
+This directory contains an [Ansible](https://www.ansible.com/) role for setting up a working environment for [Pulumi](https://pulumi.io). Using this role allows users to easily create working environments for Pulumi using a local hypervisor or a cloud instance.
+
+To use this role, simply add the path to the role to the `roles:` section of your Ansible playbook.

--- a/ansible/pulumi-env/roles/pulumi-env/defaults/main.yml
+++ b/ansible/pulumi-env/roles/pulumi-env/defaults/main.yml
@@ -1,0 +1,9 @@
+---
+pulumi_package_files:
+  - pulumi
+  - pulumi-language-go
+  - pulumi-language-nodejs
+  - pulumi-language-python
+  - pulumi-language-python-exec
+  - pulumi-resource-pulumi-nodejs
+pulumi_download_url: "https://get.pulumi.com/releases/sdk"

--- a/ansible/pulumi-env/roles/pulumi-env/tasks/main.yml
+++ b/ansible/pulumi-env/roles/pulumi-env/tasks/main.yml
@@ -1,0 +1,37 @@
+---
+- name: Download the Pulumi installation tarball
+  unarchive:
+    remote_src: true
+    src: "{{ pulumi_download_url }}/pulumi-v{{ pulumi_version }}-linux-x64.tar.gz"
+    dest: "/tmp"
+    creates: "/usr/local/bin/pulumi"
+  register: pulumi_downloaded
+
+- name: Move Pulumi binaries into path
+  copy:
+    remote_src: true
+    src: "/tmp/pulumi/{{ item }}"
+    dest: "/usr/local/bin/{{ item }}"
+  with_items: "{{ pulumi_package_files }}"
+  when: pulumi_downloaded is changed
+  register: pulumi_copied
+
+- name: Set permissions on Pulumi binaries
+  file:
+    dest: "/usr/local/bin/{{ item }}"
+    mode: 0755
+    state: "file"
+  with_items: "{{ pulumi_package_files }}"
+  when: pulumi_copied is changed
+
+- name: Update apt cache
+  apt:
+    update_cache: true
+    cache_valid_time: 3600
+
+- name: Install NodeJS
+  apt:
+    name: "{{ item }}"
+    state: "latest"
+  with_items:
+    - nodejs

--- a/ansible/pulumi-env/roles/pulumi-env/vars/main.yml
+++ b/ansible/pulumi-env/roles/pulumi-env/vars/main.yml
@@ -1,0 +1,2 @@
+---
+pulumi_version: "0.17.1"


### PR DESCRIPTION
This PR adds an Ansible role that will simplify creating a working Pulumi environment in a VM or a cloud instance.