### PR TITLE
[WIP] Add example of Vagrant triggers to create Docker contexts

### DIFF
--- a/vagrant/auto-docker-contexts/Vagrantfile
+++ b/vagrant/auto-docker-contexts/Vagrantfile
@@ -1,0 +1,99 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Specify minimum Vagrant version and Vagrant API version
+Vagrant.require_version '>= 1.6.0'
+VAGRANTFILE_API_VERSION = '2'
+
+# Require 'yaml' module
+require 'yaml'
+
+# Read YAML file with VM details (box, CPU, and RAM)
+machines = YAML.load_file(File.join(File.dirname(__FILE__), 'machines.yml'))
+
+# Create and configure the VMs
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+
+  # Always use Vagrant's default insecure key
+  config.ssh.insert_key = false
+
+  # Iterate through entries in YAML file to create VMs
+  machines.each do |machine|
+
+    # Configure the AWS provider
+    config.vm.provider 'aws' do |aws|
+
+      # Specify default AWS key pair
+      aws.keypair_name = machine['aws']['keypair']
+
+      # Specify default region
+      aws.region = machine['aws']['region']
+    end # config.vm.provider 'aws'
+
+    config.vm.define machine['name'] do |srv|
+
+      # Don't check for box updates
+      srv.vm.box_check_update = false
+
+      # Set machine's hostname
+      srv.vm.hostname = machine['name']
+
+      # Use dummy AWS box by default (override per-provider)
+      srv.vm.box = 'aws-dummy'
+
+      # Configure default synced folder (disable by default)
+      if machine['sync_disabled'] != nil
+        srv.vm.synced_folder '.', '/vagrant', disabled: machine['sync_disabled']
+      else
+        srv.vm.synced_folder '.', '/vagrant', disabled: true
+      end #if machine['sync_disabled']
+
+      # Iterate through networks as per settings in machines.yml
+      machine['nics'].each do |net|
+        if net['ip_addr'] == 'dhcp'
+          srv.vm.network net['type'], type: net['ip_addr']
+        else
+          srv.vm.network net['type'], ip: net['ip_addr']
+        end # if net['ip_addr']
+      end # machine['nics'].each
+
+      # Configure CPU & RAM per settings in machines.yml (Fusion)
+      srv.vm.provider 'vmware_fusion' do |vmw, override|
+        vmw.vmx['memsize'] = machine['ram']
+        vmw.vmx['numvcpus'] = machine['vcpu']
+        override.vm.box = machine['box']['vmw']
+        if machine['nested'] == true
+          vmw.vmx['vhv.enable'] = 'TRUE'
+        end #if machine['nested']
+      end # srv.vm.provider 'vmware_fusion'
+
+      # Configure CPU & RAM per settings in machines.yml (VirtualBox)
+      srv.vm.provider 'virtualbox' do |vb, override|
+        vb.memory = machine['ram']
+        vb.cpus = machine['vcpu']
+        override.vm.box = machine['box']['vb']
+        vb.customize ['modifyvm', :id, '--nictype1', 'virtio']
+        vb.customize ['modifyvm', :id, '--nictype2', 'virtio']
+      end # srv.vm.provider 'virtualbox'
+
+      # Configure CPU & RAM per settings in machines.yml (Libvirt)
+      srv.vm.provider 'libvirt' do |lv,override|
+        lv.memory = machine['ram']
+        lv.cpus = machine['vcpu']
+        override.vm.box = machine['box']['lv']
+        if machine['nested'] == true
+          lv.nested = true
+        end # if machine['nested']
+      end # srv.vm.provider 'libvirt'
+
+      # Configure per-machine AWS provider/instance overrides
+      srv.vm.provider 'aws' do |aws, override|
+        override.ssh.private_key_path = machine['aws']['key_path']
+        override.ssh.username = machine['aws']['user']
+        aws.instance_type = machine['aws']['type']
+        aws.ami = machine['box']['aws']
+        aws.security_groups = machine['aws']['security_groups']
+      end # srv.vm.provider 'aws'
+    end # config.vm.define
+  end # machines.each
+end # Vagrant.configure

--- a/vagrant/auto-docker-contexts/machines.yml
+++ b/vagrant/auto-docker-contexts/machines.yml
@@ -1,0 +1,23 @@
+---
+- aws:
+    type: "t2.medium"
+    user: "ubuntu"
+    key_path: "~/.ssh/aws_rsa"
+    security_groups:
+      - "default"
+      - "test"
+    keypair: "aws_rsa"
+    region: "us-west-2"
+  box:
+    aws: "ami-0c007ac192ba0744b"
+    lv: "generic/ubuntu2004"
+    vb: "ubuntu/focal64"
+    vmw: "generic/ubuntu2004"
+  name: "focal-docker"
+  nested: false
+  nics:
+    - type: "private_network"
+      ip_addr: "dhcp"
+  ram: "512"
+  sync_disabled: true
+  vcpu: "1"


### PR DESCRIPTION
This PR will add an example and supporting documentation of how to use Vagrant triggers to set up Docker contexts. This would simplify the workflow for users using Vagrant VMs for Docker-based workflows.

Closes #133.