### PR TITLE
[Enhancement] Added new AWS resources for Terraform learning tool

### DIFF
--- a/terraform/aws/new-beanstalk/main.tf
+++ b/terraform/aws/new-beanstalk/main.tf
@@ -1,0 +1,11 @@
+resource "aws_elastic_beanstalk_application" "demo_beanstalk_application" {
+  name        = var.demo_beanstalk_application_name
+  description = var.demo_beanstalk_application_description
+}
+
+resource "aws_elastic_beanstalk_environment" "demo_beanstalk_environment" {
+  name                = var.demo_beanstalk_environment_name
+  application         = aws_elastic_beanstalk_application.demo_beanstalk_application.name
+  // For all supported AWS BeanStalk Platforms / Stacks refer : https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/concepts.platforms.html
+  solution_stack_name = var.demo_beanstalk_environment_platform
+}

--- a/terraform/aws/new-beanstalk/outputs.tf
+++ b/terraform/aws/new-beanstalk/outputs.tf
@@ -1,0 +1,7 @@
+output "demo_beanstalk_application_name" {
+  value = "${aws_elastic_beanstalk_application.demo_beanstalk_application.name}"
+}
+
+output "demo_beanstalk_environment_name" {
+  value = "${aws_elastic_beanstalk_environment.demo_beanstalk_environment.name}"
+}

--- a/terraform/aws/new-beanstalk/readme.md
+++ b/terraform/aws/new-beanstalk/readme.md
@@ -1,0 +1,28 @@
+## AWS BeanStalk
+
+| Provider | Description |
+|------|---------|
+| aws | This code will create AWS BeanStalk application and environment |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_elastic_beanstalk_application.demo_beanstalk_application](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elastic_beanstalk_application) | resource |
+| [aws_elastic_beanstalk_environment.demo_beanstalk_environment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elastic_beanstalk_environment) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| demo_beanstalk_application_name | AWS beanstalk application name | `string` | `""` | yes |
+| demo_beanstalk_application_description | AWS beanstalk application description | `string` | `""` | no |
+| demo_beanstalk_environment_name | AWS beanstalk environment name | `string` | `""` | yes |
+| demo_beanstalk_environment_platform | AWS beanstalk environment platform | `string` | `"64bit Amazon Linux 2015.03 v2.0.3 running Go 1.4"` | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| demo_beanstalk_application_name | output beanstalk application name |
+| demo_beanstalk_environment_name | output beanstalk environment name |

--- a/terraform/aws/new-beanstalk/variables.tf
+++ b/terraform/aws/new-beanstalk/variables.tf
@@ -1,0 +1,25 @@
+// Define application variables
+variable "demo_beanstalk_application_name" {
+  type = "string"
+  default = ""
+  description = "AWS beanstalk application name"
+}
+
+variable "demo_beanstalk_application_description" {
+  type = "string"
+  default = ""
+  description = "AWS beanstalk application description"
+}
+
+// Define environment variables
+variable "demo_beanstalk_environment_name" {
+  type = "string"
+  default = ""
+  description = "AWS beanstalk environment name"
+}
+
+variable "demo_beanstalk_environment_platform" {
+  type = "string"
+  default = "64bit Amazon Linux 2015.03 v2.0.3 running Go 1.4"
+  description = "AWS beanstalk environment platform"
+}

--- a/terraform/aws/new-elasticache/main.tf
+++ b/terraform/aws/new-elasticache/main.tf
@@ -1,0 +1,22 @@
+// Create a demo memcached cluster
+resource "aws_elasticache_cluster" "demo_elasticache_memcached_cluster" {
+  cluster_id           = var.demo_elasticache_memcached_cluster_name
+  engine               = "memcached"
+  // Using smallest node type. Refer AWS docs for all supported node types : https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheNodes.SupportedTypes.html
+  node_type            = "cache.t3.micro"
+  num_cache_nodes      = 2
+  parameter_group_name = "default.memcached1.4"
+  port                 = 11211
+}
+
+// Create a demo redis cluster
+resource "aws_elasticache_cluster" "demo_elasticache_redis_cluster" {
+  cluster_id           = var.demo_elasticache_redis_cluster_name
+  engine               = "redis"
+  // Using smallest node type. Refer AWS docs for all supported node types : https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheNodes.SupportedTypes.html
+  node_type            = "cache.t3.micro"
+  num_cache_nodes      = 1
+  parameter_group_name = "default.redis3.2"
+  engine_version       = "3.2.10"
+  port                 = 6379
+}

--- a/terraform/aws/new-elasticache/output.tf
+++ b/terraform/aws/new-elasticache/output.tf
@@ -1,0 +1,7 @@
+output "demo_elasticache_memcached_cluster_name" {
+  value = "${aws_elasticache_cluster.demo_elasticache_memcached_cluster.cluster_id}"
+}
+
+output "demo_elasticache_redis_cluster_name" {
+  value = "${aws_elasticache_cluster.demo_elasticache_redis_cluster.cluster_id}"
+}

--- a/terraform/aws/new-elasticache/readme.md
+++ b/terraform/aws/new-elasticache/readme.md
@@ -1,0 +1,26 @@
+## AWS Elasticache
+
+| Provider | Description |
+|------|---------|
+| aws | This code will create AWS Elasticache memcached and redis clusters |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_elasticache_cluster.demo_elasticache_memcached_cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_cluster) | resource |
+| [aws_elasticache_cluster.demo_elasticache_redis_cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_cluster) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| demo_elasticache_memcached_cluster_name | AWS memcached elasticache cluster name | `string` | `""` | yes |
+| demo_elasticache_redis_cluster_name | AWS redis elasticache cluster name | `string` | `""` | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| demo_elasticache_memcached_cluster_name | output memcached elasticache cluster name |
+| demo_elasticache_redis_cluster_name | output redis elasticache cluster name |

--- a/terraform/aws/new-elasticache/variables.tf
+++ b/terraform/aws/new-elasticache/variables.tf
@@ -1,0 +1,11 @@
+variable "demo_elasticache_memcached_cluster_name" {
+  type = "string"
+  default = ""
+  description = "AWS memcached elasticache cluster name"
+}
+
+variable "demo_elasticache_redis_cluster_name" {
+  type = "string"
+  default = ""
+  description = "AWS redis elasticache cluster name"
+}

--- a/terraform/aws/new-igw/main.tf
+++ b/terraform/aws/new-igw/main.tf
@@ -1,0 +1,7 @@
+resource "aws_internet_gateway" "gw" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = "main"
+  }
+}

--- a/terraform/aws/new-igw/main.tf
+++ b/terraform/aws/new-igw/main.tf
@@ -1,4 +1,4 @@
-resource "aws_internet_gateway" "demo_gw" {
+resource "aws_internet_gateway" "demo_igw" {
   vpc_id = var.demo_vpc_id
 
   tags {

--- a/terraform/aws/new-igw/main.tf
+++ b/terraform/aws/new-igw/main.tf
@@ -1,7 +1,7 @@
-resource "aws_internet_gateway" "gw" {
-  vpc_id = aws_vpc.main.id
+resource "aws_internet_gateway" "demo_gw" {
+  vpc_id = var.demo_vpc_id
 
-  tags = {
-    Name = "main"
+  tags {
+    tool = "terraform"
   }
 }

--- a/terraform/aws/new-igw/output.tf
+++ b/terraform/aws/new-igw/output.tf
@@ -1,0 +1,3 @@
+output "demo_igw_id" {
+  value = "${aws_internet_gateway.demo_igw.id}"
+}

--- a/terraform/aws/new-igw/readme.md
+++ b/terraform/aws/new-igw/readme.md
@@ -1,0 +1,23 @@
+## AWS IGW
+
+| Provider | Description |
+|------|---------|
+| aws | This code will create an AWS Internet Gateway |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_internet_gateway.demo_igw](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/internet_gateway) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| demo_vpc_id | AWS coreos\_vpc VPC ID | `string` | `""` | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| output_demo_igw_id | output IGW resource ID |

--- a/terraform/aws/new-igw/variables.tf
+++ b/terraform/aws/new-igw/variables.tf
@@ -1,0 +1,6 @@
+// note: this variable will be fed with coreos_vpc VPC ID which can be found at terraform/aws/new-vpc/main.tf
+variable "demo_vpc_id" {
+  type = "string"
+  default = ""
+  description = "AWS coreos_vpc VPC ID"
+}

--- a/terraform/aws/new-natgw/main.tf
+++ b/terraform/aws/new-natgw/main.tf
@@ -1,0 +1,20 @@
+// Create a Elastic IP for NAT GW
+resource "aws_eip" "demo_gw_eip" {
+  vpc          = true
+  tags = {
+    tool = "terraform"
+  }
+}
+
+// Create a NAT GW in public1 and public2 subnets
+resource "aws_nat_gateway" "ease_prod_vpc_nat_gws" {
+  count         = length(var.ease_prod_vpc_public_subnets)
+  allocation_id = aws_eip.demo_gw_eip.id
+  # feed coreos_subnet public subnet ID
+  subnet_id     = var.coreos_subnet_id
+
+  tags = {
+    tool = "terraform"
+  }
+  depends_on = [aws_eip.demo_gw_eip]
+}

--- a/terraform/aws/new-natgw/main.tf
+++ b/terraform/aws/new-natgw/main.tf
@@ -7,8 +7,7 @@ resource "aws_eip" "demo_gw_eip" {
 }
 
 // Create a NAT GW in public1 and public2 subnets
-resource "aws_nat_gateway" "ease_prod_vpc_nat_gws" {
-  count         = length(var.ease_prod_vpc_public_subnets)
+resource "aws_nat_gateway" "demo_natgw" {
   allocation_id = aws_eip.demo_gw_eip.id
   # feed coreos_subnet public subnet ID
   subnet_id     = var.coreos_subnet_id

--- a/terraform/aws/new-natgw/output.tf
+++ b/terraform/aws/new-natgw/output.tf
@@ -1,0 +1,3 @@
+output "demo_natgw_id" {
+  value = "${aws_nat_gateway.demo_natgw.id}"
+}

--- a/terraform/aws/new-natgw/readme.md
+++ b/terraform/aws/new-natgw/readme.md
@@ -1,0 +1,24 @@
+## AWS NAT GW
+
+| Provider | Description |
+|------|---------|
+| aws | This code will create an AWS NAT Gateway |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_eip.demo_gw_eip](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip) | resource |
+| [aws_nat_gateway.demo_natgw](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/nat_gateway) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| coreos_subnet_id | AWS coreos\_vpc subnet ID | `string` | `""` | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| output_demo_natgw_id | output NAT GW resource ID |

--- a/terraform/aws/new-natgw/variables.tf
+++ b/terraform/aws/new-natgw/variables.tf
@@ -1,0 +1,6 @@
+// note: this variable will be fed with coreos_subnet subnet ID which can be found at terraform/aws/new-vpc/main.tf
+variable "coreos_subnet_id" {
+  type = "string"
+  default = ""
+  description = "AWS coreos_vpc subnet ID"
+}

--- a/terraform/aws/new-s3/main.tf
+++ b/terraform/aws/new-s3/main.tf
@@ -1,0 +1,15 @@
+// Create a demo S3 bucket
+resource "aws_s3_bucket" "demo_s3" {
+  bucket = var.demo_s3_name
+  acl    = "private"
+
+  # enable versioning on bucket
+  versioning {
+    enabled = true
+  }
+
+  tags = {
+    Name  = "learning-tools"
+    tools = "terraform"
+  }
+}

--- a/terraform/aws/new-s3/output.tf
+++ b/terraform/aws/new-s3/output.tf
@@ -1,0 +1,3 @@
+output "demo_s3_id" {
+  value = "${aws_s3_bucket.demo_s3.id}"
+}

--- a/terraform/aws/new-s3/readme.md
+++ b/terraform/aws/new-s3/readme.md
@@ -1,0 +1,23 @@
+## AWS S3
+
+| Provider | Description |
+|------|---------|
+| aws | This code will create an AWS S3 bucket |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_s3_bucket.demo_s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| demo_s3_name | demo S3 bucket for terraform in learning-tools | `string` | `"learning-tools-demo-s3"` | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| output_demo_s3_id | output S3 bucket resource ID |

--- a/terraform/aws/new-s3/variables.tf
+++ b/terraform/aws/new-s3/variables.tf
@@ -1,0 +1,5 @@
+variable "demo_s3_name" {
+  type = "string"
+  default = "learning-tools-demo-s3"
+  description = "demo S3 bucket for terraform in learning-tools"
+}


### PR DESCRIPTION
Hey @scottslowe 

As we discussed in https://github.com/scottslowe/learning-tools/issues/137 submitting PR with following new AWS resources: 
```
1. Internet Gateway
2. NAT Gateway
3. S3
4. Elasticache (memcached + redis clusters)
5. BeanStalk (application + environment)
```

Let me know if any corrections :)