### PR TITLE
Add Pulumi example for using default AWS infrastructure

### DIFF
--- a/pulumi/default-aws-infra/README.md
+++ b/pulumi/default-aws-infra/README.md
@@ -1,0 +1,43 @@
+# Using the Default AWS Infrastructure
+
+This set of files provides an example on how to use the "default AWS infrastructure" (the VPC, subnets, and Internet gateway that are automatically created for you in a region when you start using AWS).
+
+This example uses [Go][link-1].
+
+## Contents
+
+* **main.go**: This Go file contains all the necessary Pulumi code to launch an EC2 instance on your default AWS infrastructure.
+
+* **README.md**: This file you're currently reading.
+
+## Instructions
+
+These instructions assume you've already installed and configured Pulumi and all necessary dependencies (Go, for this example). Please refer to the Pulumi documentation for more details on installation or configuration.
+
+1. Start a new Pulumi project, configured for AWS and Go (you can use `pulumi new` for this step if you prefer).
+
+2. Copy `main.go` from this directory into the directory for the new Pulumi project.
+
+3. Edit `main.go` as outlined below in the section "Providing Your Own Information".
+
+4. Once `main.go` has been appropriately customized for your specific environment, run `pulumi up` and follow the prompts.
+
+Enjoy!
+
+## Providing Your Own Information
+
+The `main.go` file provided in this folder **will not work** without providing your own information. This section outlines the changes that need to be made to the `main.go` file.
+
+1. On line 82, verify the AMI ID specified there (everything before `_VERIFY_ME`) is valid for the AWS region you will use. Change this as necessary to a valid AMI ID for your region.
+
+2. On line 83, verify the instance type (everything before `_VERIFY_ME`) is valid for your AWS region. Change as necessary.
+
+3. On line 85, replace `CHANGE_ME` with the name of a valid key pair.
+
+After making these changes, you should be able to run `pulumi up` without any issues.
+
+## License
+
+This content is licensed under the MIT License.
+
+[link-1]: https://go.dev

--- a/pulumi/default-aws-infra/main.go
+++ b/pulumi/default-aws-infra/main.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"log"
+
+	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws"
+	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ec2"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		// Look up the default VPC
+		isDefault := true
+		desiredState := "available"
+		vpc, err := ec2.LookupVpc(ctx, &ec2.LookupVpcArgs{
+			Default: &isDefault,
+			State:   &desiredState,
+		},
+		)
+		if err != nil {
+			log.Printf("error looking up VPC: %s", err.Error())
+			return err
+		}
+		ctx.Export("defaultVpcId", pulumi.String(vpc.Id))
+
+		// Look up availability zones in the desired region
+		rawAzInfo, err := aws.GetAvailabilityZones(ctx, &aws.GetAvailabilityZonesArgs{
+			State: &desiredState,
+		})
+		if err != nil {
+			log.Printf("error getting AZs: %s", err.Error())
+			return err
+		}
+
+		// Determine how many AZs are present
+		numOfAZs := len(rawAzInfo.Names)
+		ctx.Export("numOfAZs", pulumi.Int(numOfAZs))
+
+		// Build a list of AZ names
+		azNames := make([]string, numOfAZs)
+		for i := 0; i < numOfAZs; i++ {
+			azNames[i] = rawAzInfo.Names[i]
+		}
+		// ctx.Export("listOfAzNames", pulumi.StringArray(azNames[]))
+
+		// Iterate through the AZs to discover subnets
+		pubSubnetIds := make([]pulumi.StringInput, numOfAZs)
+		privSubnetIds := make([]pulumi.StringInput, numOfAZs)
+		for i := 0; i < numOfAZs; i++ {
+			selectedAz := azNames[i]
+			azDefault := true
+			subnet, err := ec2.LookupSubnet(ctx, &ec2.LookupSubnetArgs{
+				AvailabilityZone: &selectedAz,
+				DefaultForAz:     &azDefault,
+				VpcId:            &vpc.Id,
+			})
+			if err != nil {
+				log.Printf("error looking up subnet in AZ: %s", err.Error())
+			}
+			if subnet.MapPublicIpOnLaunch {
+				pubSubnetIds[i] = pulumi.String(subnet.Id)
+			} else {
+				privSubnetIds[i] = pulumi.String(subnet.Id)
+			}
+		}
+		ctx.Export("pubSubnetIds", pulumi.StringArray(pubSubnetIds))
+		ctx.Export("privSubnetIds", pulumi.StringArray(privSubnetIds))
+
+		// Identify default SG
+		defaultSgName := "default"
+		sg, err := ec2.LookupSecurityGroup(ctx, &ec2.LookupSecurityGroupArgs{
+			Name: &defaultSgName,
+		})
+		if err != nil {
+			log.Printf("error looking up default security group: %s", err.Error())
+		}
+		ctx.Export("defaultSgId", pulumi.String(sg.Id))
+
+		// Launch an instance
+		instance, err := ec2.NewInstance(ctx, "instance", &ec2.InstanceArgs{
+			Ami:                      pulumi.String("ami-0aab355e1bfa1e72e_VERIFY_ME"),
+			InstanceType:             pulumi.String("t3a.small_VERIFY_ME"),
+			AssociatePublicIpAddress: pulumi.Bool(true),
+			KeyName:                  pulumi.String("CHANGE_ME"),
+			SubnetId:                 pubSubnetIds[0],
+			SourceDestCheck:          pulumi.Bool(false),
+			VpcSecurityGroupIds:      pulumi.StringArray{pulumi.String(sg.Id)},
+			Tags: pulumi.StringMap{
+				"Name": pulumi.String("instance"),
+			},
+		})
+		if err != nil {
+			log.Printf("error launching instance: %s", err.Error())
+		}
+		ctx.Export("instanceId", instance.ID())
+		ctx.Export("instancePublicIpAddress", instance.PublicIp)
+		ctx.Export("instancePrivateIpAddress", instance.PrivateIp)
+
+		// End
+		return nil
+	})
+}


### PR DESCRIPTION
This PR adds some Go-based code to show how to use Pulumi to launch an EC2 instance in/on the "default" AWS infrastructure created for every user (the default VPC, subnets, and Internet gateway).