### PR TITLE
Add a Pulumi program to deploy a Debian-based EC2 instance

### DIFF
--- a/debian/debian-pulumi-aws/Pulumi.yaml
+++ b/debian/debian-pulumi-aws/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: debian-pulumi-aws
+runtime: go
+description: A Go Pulumi program to stand up a Debian instance on AWS

--- a/debian/debian-pulumi-aws/README.md
+++ b/debian/debian-pulumi-aws/README.md
@@ -1,0 +1,47 @@
+# Debian on AWS Using Pulumi
+
+These files were created to allow users to quickly and easily deploy a Debian EC2 instance using [Pulumi](https://www.pulumi.com). This Pulumi program was written in [Go](https://go.dev).
+
+While not complex, the Pulumi program here does illustrate a few things that might be useful for newer users:
+
+* Use of the `value, ok := map[key]` idiom for checking configuration values passed in from the user
+* Supporting both X86_64/AMD64- as well as ARM64-based configurations
+* Dynamically looking up an AMI
+* Modifying the default values for an AWSX VPC to create only public subnets
+
+## Contents
+
+* `go.mod`: This file contains dependencies used by this Go program.
+
+* `go.sum`: This file contains checksums for each of the direct and indirect dependencies. The checksum is used to validate that none of them has been modified.
+
+* `main.go`: This Go file is the Pulumi program executed by the `pulumi` CLI, and contains the resource definitions to create a VPC with only public subnets, a security group to allow SSH access, and a Debian-based EC2 instance in one of the public subnets.
+
+* `Pulumi.yaml`: This is the Pulumi project file.
+
+* `README.md`: This file you're currently reading.
+
+## Instructions
+These instructions assume you've already installed and configured Pulumi and all necessary dependencies (Go, for this example). Please refer to the Pulumi documentation for more details on installation or configuration.
+
+1. Copy the contents of this directory down to a directory on your system, or clone the entire repository and then change into the directory where this section of the cloned repository resides.
+
+1. Run `pulumi stack init` to create a new stack.
+
+1. Run `pulumi config set aws:region <region-name>` to set the AWS region where the Pulumi program should create resources. _This is a required configuration value; CLI operations will fail if you don't set this value._
+
+1. Run `pulumi config set keypairname <name-of-aws-keypair>` to set the name of the AWS keypair that should be used. _This is a required configuration value._
+
+1. (Optional) Run `pulumi config set` to set configuration values that affect the behavior of the Pulumi program. The optional configuration values are:
+
+    * `architecture`: Set this to "amd64" or "arm64". The values "x86_64" and "x64" are also supported and will have the same effect as "amd64". The default value is "arm64".
+    * `networkcidr`: Set this to control the CIDR that will be used when the VPC is created. The default value is "10.0.0.0/16".
+    * `versionname`: Set this to "buster", "bullseye", or "bookworm" to control the version of Debian used in the EC2 instance. These version names correspond to version numbers 10, 11, and 12, respectively. The default value is "bookworm".
+
+1. Run `pulumi up` to instantiate the resources.
+
+Enjoy! When you're finished, run `pulumi destroy` to tear down all the provisioned resources.
+
+## License
+
+This content is licensed under the MIT License.

--- a/debian/debian-pulumi-aws/go.mod
+++ b/debian/debian-pulumi-aws/go.mod
@@ -2,16 +2,18 @@ module debian-pulumi-aws
 
 go 1.21
 
-toolchain go1.21.0
-
-require github.com/pulumi/pulumi/sdk/v3 v3.86.0
+require (
+	github.com/pulumi/pulumi-aws/sdk/v6 v6.8.0
+	github.com/pulumi/pulumi-awsx/sdk/v2 v2.1.1
+	github.com/pulumi/pulumi/sdk/v3 v3.91.1
+)
 
 require (
 	github.com/Microsoft/go-winio v0.5.2 // indirect
 	github.com/ProtonMail/go-crypto v0.0.0-20221026131551-cf6655e29de4 // indirect
 	github.com/acomagu/bufpipe v1.0.3 // indirect
 	github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da // indirect
-	github.com/agext/levenshtein v1.2.1 // indirect
+	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
@@ -33,9 +35,9 @@ require (
 	github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
-	github.com/hashicorp/hcl/v2 v2.16.1 // indirect
+	github.com/hashicorp/hcl/v2 v2.17.0 // indirect
 	github.com/imdario/mergo v0.3.13 // indirect
-	github.com/inconshreveable/mousetrap v1.0.1 // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
@@ -43,7 +45,7 @@ require (
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.14 // indirect
 	github.com/mitchellh/go-ps v1.0.0 // indirect
-	github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7 // indirect
+	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/muesli/ansi v0.0.0-20211018074035-2e021307bc4b // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/reflow v0.3.0 // indirect
@@ -53,29 +55,33 @@ require (
 	github.com/pjbgf/sha1cd v0.3.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pkg/term v1.1.0 // indirect
+	github.com/pulumi/esc v0.5.6 // indirect
+	github.com/pulumi/pulumi-docker/sdk/v4 v4.4.3 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
-	github.com/rogpeppe/go-internal v1.9.0 // indirect
+	github.com/rogpeppe/go-internal v1.11.0 // indirect
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 // indirect
 	github.com/santhosh-tekuri/jsonschema/v5 v5.0.0 // indirect
-	github.com/sergi/go-diff v1.2.0 // indirect
+	github.com/sergi/go-diff v1.3.1 // indirect
 	github.com/skeema/knownhosts v1.1.0 // indirect
-	github.com/spf13/cobra v1.6.1 // indirect
+	github.com/spf13/cast v1.4.1 // indirect
+	github.com/spf13/cobra v1.7.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
 	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
 	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
 	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
-	github.com/zclconf/go-cty v1.12.1 // indirect
+	github.com/zclconf/go-cty v1.13.2 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
-	golang.org/x/crypto v0.3.1-0.20221117191849-2c476679df9a // indirect
-	golang.org/x/net v0.10.0 // indirect
-	golang.org/x/sync v0.1.0 // indirect
-	golang.org/x/sys v0.8.0 // indirect
-	golang.org/x/term v0.8.0 // indirect
-	golang.org/x/text v0.9.0 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20230706204954-ccb25ca9f130 // indirect
-	google.golang.org/grpc v1.57.0 // indirect
+	golang.org/x/crypto v0.14.0 // indirect
+	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
+	golang.org/x/net v0.17.0 // indirect
+	golang.org/x/sync v0.2.0 // indirect
+	golang.org/x/sys v0.13.0 // indirect
+	golang.org/x/term v0.13.0 // indirect
+	golang.org/x/text v0.13.0 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20230731190214-cbb8c96f2d6d // indirect
+	google.golang.org/grpc v1.57.1 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/debian/debian-pulumi-aws/go.mod
+++ b/debian/debian-pulumi-aws/go.mod
@@ -1,0 +1,84 @@
+module debian-pulumi-aws
+
+go 1.21
+
+toolchain go1.21.0
+
+require github.com/pulumi/pulumi/sdk/v3 v3.86.0
+
+require (
+	github.com/Microsoft/go-winio v0.5.2 // indirect
+	github.com/ProtonMail/go-crypto v0.0.0-20221026131551-cf6655e29de4 // indirect
+	github.com/acomagu/bufpipe v1.0.3 // indirect
+	github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da // indirect
+	github.com/agext/levenshtein v1.2.1 // indirect
+	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
+	github.com/atotto/clipboard v0.1.4 // indirect
+	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
+	github.com/blang/semver v3.5.1+incompatible // indirect
+	github.com/charmbracelet/bubbles v0.16.1 // indirect
+	github.com/charmbracelet/bubbletea v0.24.2 // indirect
+	github.com/charmbracelet/lipgloss v0.7.1 // indirect
+	github.com/cheggaaa/pb v1.0.29 // indirect
+	github.com/cloudflare/circl v1.3.3 // indirect
+	github.com/containerd/console v1.0.4-0.20230313162750-1ae8d489ac81 // indirect
+	github.com/djherbis/times v1.5.0 // indirect
+	github.com/emirpasic/gods v1.18.1 // indirect
+	github.com/go-git/gcfg v1.5.0 // indirect
+	github.com/go-git/go-billy/v5 v5.4.0 // indirect
+	github.com/go-git/go-git/v5 v5.6.0 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/glog v1.1.0 // indirect
+	github.com/golang/protobuf v1.5.3 // indirect
+	github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645 // indirect
+	github.com/hashicorp/errwrap v1.1.0 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
+	github.com/hashicorp/hcl/v2 v2.16.1 // indirect
+	github.com/imdario/mergo v0.3.13 // indirect
+	github.com/inconshreveable/mousetrap v1.0.1 // indirect
+	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
+	github.com/kevinburke/ssh_config v1.2.0 // indirect
+	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
+	github.com/mattn/go-isatty v0.0.18 // indirect
+	github.com/mattn/go-localereader v0.0.1 // indirect
+	github.com/mattn/go-runewidth v0.0.14 // indirect
+	github.com/mitchellh/go-ps v1.0.0 // indirect
+	github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7 // indirect
+	github.com/muesli/ansi v0.0.0-20211018074035-2e021307bc4b // indirect
+	github.com/muesli/cancelreader v0.2.2 // indirect
+	github.com/muesli/reflow v0.3.0 // indirect
+	github.com/muesli/termenv v0.15.1 // indirect
+	github.com/opentracing/basictracer-go v1.1.0 // indirect
+	github.com/opentracing/opentracing-go v1.2.0 // indirect
+	github.com/pjbgf/sha1cd v0.3.0 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pkg/term v1.1.0 // indirect
+	github.com/rivo/uniseg v0.4.4 // indirect
+	github.com/rogpeppe/go-internal v1.9.0 // indirect
+	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 // indirect
+	github.com/santhosh-tekuri/jsonschema/v5 v5.0.0 // indirect
+	github.com/sergi/go-diff v1.2.0 // indirect
+	github.com/skeema/knownhosts v1.1.0 // indirect
+	github.com/spf13/cobra v1.6.1 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
+	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
+	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
+	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
+	github.com/xanzy/ssh-agent v0.3.3 // indirect
+	github.com/zclconf/go-cty v1.12.1 // indirect
+	go.uber.org/atomic v1.9.0 // indirect
+	golang.org/x/crypto v0.3.1-0.20221117191849-2c476679df9a // indirect
+	golang.org/x/net v0.10.0 // indirect
+	golang.org/x/sync v0.1.0 // indirect
+	golang.org/x/sys v0.8.0 // indirect
+	golang.org/x/term v0.8.0 // indirect
+	golang.org/x/text v0.9.0 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20230706204954-ccb25ca9f130 // indirect
+	google.golang.org/grpc v1.57.0 // indirect
+	google.golang.org/protobuf v1.31.0 // indirect
+	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+	lukechampine.com/frand v1.4.2 // indirect
+	sourcegraph.com/sourcegraph/appdash v0.0.0-20211028080628-e2786a622600 // indirect
+)

--- a/debian/debian-pulumi-aws/main.go
+++ b/debian/debian-pulumi-aws/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		return nil
+	})
+}

--- a/debian/debian-pulumi-aws/main.go
+++ b/debian/debian-pulumi-aws/main.go
@@ -1,11 +1,126 @@
 package main
 
 import (
+	"fmt"
+	"log"
+
+	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/ec2"
+	awsx "github.com/pulumi/pulumi-awsx/sdk/v2/go/awsx/ec2"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
 )
 
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
+		// Set up maps that are used later
+		versionMap := map[string]int{"buster": 10, "bullseye": 11, "bookworm": 12}
+		typeMap := map[string]string{"amd64": "t3a.small", "arm64": "t4g.small", "x86_64": "t3a.small", "x64": "t3a.small"}
+
+		// Retrieve configuration values
+		keyPair := config.Require(ctx, "keypairname")
+		instanceCpuArch, err := config.Try(ctx, "architecture")
+		if err != nil {
+			instanceCpuArch = "arm64"
+		}
+		instanceType, ok := typeMap[instanceCpuArch]
+		if !ok {
+			instanceCpuArch = "arm64"
+			instanceType = "t4g.small"
+		}
+		if instanceCpuArch == "x86_64" || instanceCpuArch == "x64" {
+			instanceCpuArch = "amd64"
+		}
+		vpcNetworkCidr, err := config.Try(ctx, "networkcidr")
+		if err != nil {
+			vpcNetworkCidr = "10.0.0.0/16"
+		}
+		versionName, err := config.Try(ctx, "version")
+		if err != nil {
+			versionName = "bookworm"
+		}
+		versionNum, ok := versionMap[versionName]
+		if !ok {
+			versionNum = 12
+		}
+
+		// Create a new VPC, subnets, and associated infrastructure
+		debianVpc, err := awsx.NewVpc(ctx, "debian-vpc", &awsx.VpcArgs{
+			CidrBlock:          &vpcNetworkCidr,
+			EnableDnsHostnames: pulumi.Bool(true),
+			EnableDnsSupport:   pulumi.Bool(true),
+			NatGateways: &awsx.NatGatewayConfigurationArgs{
+				Strategy: awsx.NatGatewayStrategyNone,
+			},
+			SubnetSpecs: []awsx.SubnetSpecArgs{
+				{
+					Type: awsx.SubnetTypePublic,
+				},
+			},
+		})
+		if err != nil {
+			log.Printf("error creating VPC: %s", err.Error())
+		}
+
+		// Create a Security Group that we can use to connect to our instance
+		debianSg, err := ec2.NewSecurityGroup(ctx, "debian-sg", &ec2.SecurityGroupArgs{
+			VpcId: debianVpc.VpcId,
+			Egress: ec2.SecurityGroupEgressArray{
+				ec2.SecurityGroupEgressArgs{
+					Protocol:   pulumi.String("-1"),
+					FromPort:   pulumi.Int(0),
+					ToPort:     pulumi.Int(0),
+					CidrBlocks: pulumi.StringArray{pulumi.String("0.0.0.0/0")},
+				},
+			},
+			Ingress: ec2.SecurityGroupIngressArray{
+				ec2.SecurityGroupIngressArgs{
+					Protocol:   pulumi.String("tcp"),
+					FromPort:   pulumi.Int(22),
+					ToPort:     pulumi.Int(22),
+					CidrBlocks: pulumi.StringArray{pulumi.String("0.0.0.0/0")},
+				},
+			},
+		})
+		if err != nil {
+			log.Printf("error creating security group: %s", err.Error())
+		}
+
+		// Get AMI ID for Debian instance
+		mostRecent := true
+		amiName := fmt.Sprintf("debian-%d-%s-*", versionNum, instanceCpuArch)
+		debianAmi, err := ec2.LookupAmi(ctx, &ec2.LookupAmiArgs{
+			Owners:     []string{"136693071363"},
+			MostRecent: &mostRecent,
+			Filters: []ec2.GetAmiFilter{
+				{Name: "name", Values: []string{amiName}},
+				{Name: "root-device-type", Values: []string{"ebs"}},
+				{Name: "virtualization-type", Values: []string{"hvm"}},
+				{Name: "architecture", Values: []string{instanceCpuArch}},
+			},
+		})
+		if err != nil {
+			log.Printf("error looking up AMI: %s", err.Error())
+		}
+
+		// Launch an instance using Debian AMI
+		debianInstance, err := ec2.NewInstance(ctx, "debian-instance", &ec2.InstanceArgs{
+			Ami:                      pulumi.String(debianAmi.Id),
+			InstanceType:             pulumi.String(instanceType),
+			AssociatePublicIpAddress: pulumi.Bool(true),
+			KeyName:                  pulumi.String(keyPair),
+			SubnetId:                 debianVpc.PublicSubnetIds.Index(pulumi.Int(0)),
+			VpcSecurityGroupIds:      pulumi.StringArray{debianSg.ID()},
+			Tags: pulumi.StringMap{
+				"Name": pulumi.String("debian-instance"),
+			},
+		})
+		if err != nil {
+			log.Printf("error launching instance: %s", err.Error())
+		}
+		ctx.Export("instanceId", debianInstance.ID())
+		ctx.Export("instancePublicIpAddress", debianInstance.PublicIp)
+		ctx.Export("instancePrivateIpAddress", debianInstance.PrivateIp)
+
 		return nil
 	})
 }


### PR DESCRIPTION
This PR adds a Pulumi program (written in Go) that deploys a Debian-based EC2 instance. The program creates a dedicated VPC with only public subnets, and supports deploying either AMD64- or ARM64-based instances. The program also supports deploying an instance with Debian 10 ("Buster"), Debian 11 ("Bullseye"), or Debian 12 ("Bookworm") via configuration values.