### PR TITLE
Add a Pulumi program to manage K8s-related AWS IAM entities

### DIFF
--- a/aws/k8s-iam-pulumi/Pulumi.yaml
+++ b/aws/k8s-iam-pulumi/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: k8s-iam-pulumi
+runtime: go
+description: A Go Pulumi program to create IAM entities for Kubernetes on AWS

--- a/aws/k8s-iam-pulumi/go.mod
+++ b/aws/k8s-iam-pulumi/go.mod
@@ -1,0 +1,94 @@
+module k8s-iam-pulumi
+
+go 1.22
+
+toolchain go1.22.1
+
+require (
+	github.com/pulumi/pulumi-aws/sdk/v6 v6.24.0
+	github.com/pulumi/pulumi/sdk/v3 v3.108.1
+)
+
+require (
+	dario.cat/mergo v1.0.0 // indirect
+	github.com/Microsoft/go-winio v0.6.1 // indirect
+	github.com/ProtonMail/go-crypto v0.0.0-20230828082145-3c4c8a2d2371 // indirect
+	github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da // indirect
+	github.com/agext/levenshtein v1.2.3 // indirect
+	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
+	github.com/atotto/clipboard v0.1.4 // indirect
+	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
+	github.com/blang/semver v3.5.1+incompatible // indirect
+	github.com/charmbracelet/bubbles v0.16.1 // indirect
+	github.com/charmbracelet/bubbletea v0.24.2 // indirect
+	github.com/charmbracelet/lipgloss v0.7.1 // indirect
+	github.com/cheggaaa/pb v1.0.29 // indirect
+	github.com/cloudflare/circl v1.3.7 // indirect
+	github.com/containerd/console v1.0.4-0.20230313162750-1ae8d489ac81 // indirect
+	github.com/cyphar/filepath-securejoin v0.2.4 // indirect
+	github.com/djherbis/times v1.5.0 // indirect
+	github.com/emirpasic/gods v1.18.1 // indirect
+	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
+	github.com/go-git/go-billy/v5 v5.5.0 // indirect
+	github.com/go-git/go-git/v5 v5.11.0 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/glog v1.1.0 // indirect
+	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
+	github.com/golang/protobuf v1.5.3 // indirect
+	github.com/google/uuid v1.3.0 // indirect
+	github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645 // indirect
+	github.com/hashicorp/errwrap v1.1.0 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
+	github.com/hashicorp/hcl/v2 v2.17.0 // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
+	github.com/kevinburke/ssh_config v1.2.0 // indirect
+	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
+	github.com/mattn/go-isatty v0.0.19 // indirect
+	github.com/mattn/go-localereader v0.0.1 // indirect
+	github.com/mattn/go-runewidth v0.0.15 // indirect
+	github.com/mitchellh/go-ps v1.0.0 // indirect
+	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
+	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
+	github.com/muesli/cancelreader v0.2.2 // indirect
+	github.com/muesli/reflow v0.3.0 // indirect
+	github.com/muesli/termenv v0.15.2 // indirect
+	github.com/opentracing/basictracer-go v1.1.0 // indirect
+	github.com/opentracing/opentracing-go v1.2.0 // indirect
+	github.com/pgavlin/fx v0.1.6 // indirect
+	github.com/pjbgf/sha1cd v0.3.0 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pkg/term v1.1.0 // indirect
+	github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231 // indirect
+	github.com/pulumi/esc v0.6.2 // indirect
+	github.com/rivo/uniseg v0.4.4 // indirect
+	github.com/rogpeppe/go-internal v1.11.0 // indirect
+	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06 // indirect
+	github.com/santhosh-tekuri/jsonschema/v5 v5.0.0 // indirect
+	github.com/sergi/go-diff v1.3.1 // indirect
+	github.com/skeema/knownhosts v1.2.1 // indirect
+	github.com/spf13/cobra v1.7.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
+	github.com/tweekmonster/luser v0.0.0-20161003172636-3fa38070dbd7 // indirect
+	github.com/uber/jaeger-client-go v2.30.0+incompatible // indirect
+	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
+	github.com/xanzy/ssh-agent v0.3.3 // indirect
+	github.com/zclconf/go-cty v1.13.2 // indirect
+	go.uber.org/atomic v1.9.0 // indirect
+	golang.org/x/crypto v0.17.0 // indirect
+	golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa // indirect
+	golang.org/x/mod v0.14.0 // indirect
+	golang.org/x/net v0.19.0 // indirect
+	golang.org/x/sync v0.5.0 // indirect
+	golang.org/x/sys v0.15.0 // indirect
+	golang.org/x/term v0.15.0 // indirect
+	golang.org/x/text v0.14.0 // indirect
+	golang.org/x/tools v0.15.0 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20230706204954-ccb25ca9f130 // indirect
+	google.golang.org/grpc v1.57.1 // indirect
+	google.golang.org/protobuf v1.31.0 // indirect
+	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+	lukechampine.com/frand v1.4.2 // indirect
+)

--- a/aws/k8s-iam-pulumi/main.go
+++ b/aws/k8s-iam-pulumi/main.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"encoding/json"
+	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/iam"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		// Create a policy for Kubernetes control plane nodes
+		tmpJSON0, err := json.Marshal(map[string]interface{}{
+			"Version": "2012-10-17",
+			"Statement": []map[string]interface{}{
+				map[string]interface{}{
+					"Action": []string{
+						"autoscaling:DescribeAutoScalingGroups",
+						"autoscaling:DescribeLaunchConfigurations",
+						"autoscaling:DescribeTags",
+						"ec2:DescribeInstances",
+						"ec2:DescribeRegions",
+						"ec2:DescribeRouteTables",
+						"ec2:DescribeSecurityGroups",
+						"ec2:DescribeSubnets",
+						"ec2:DescribeVolumes",
+						"ec2:DescribeAvailabilityZones",
+						"ec2:CreateSecurityGroup",
+						"ec2:CreateTags",
+						"ec2:CreateVolume",
+						"ec2:ModifyInstanceAttribute",
+						"ec2:ModifyVolume",
+						"ec2:AttachVolume",
+						"ec2:AuthorizeSecurityGroupIngress",
+						"ec2:CreateRoute",
+						"ec2:DeleteRoute",
+						"ec2:DeleteSecurityGroup",
+						"ec2:DeleteVolume",
+						"ec2:DetachVolume",
+						"ec2:RevokeSecurityGroupIngress",
+						"ec2:DescribeVpcs",
+						"elasticloadbalancing:AddTags",
+						"elasticloadbalancing:AttachLoadBalancerToSubnets",
+						"elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",
+						"elasticloadbalancing:CreateLoadBalancer",
+						"elasticloadbalancing:CreateLoadBalancerPolicy",
+						"elasticloadbalancing:CreateLoadBalancerListeners",
+						"elasticloadbalancing:ConfigureHealthCheck",
+						"elasticloadbalancing:DeleteLoadBalancer",
+						"elasticloadbalancing:DeleteLoadBalancerListeners",
+						"elasticloadbalancing:DescribeLoadBalancers",
+						"elasticloadbalancing:DescribeLoadBalancerAttributes",
+						"elasticloadbalancing:DetachLoadBalancerFromSubnets",
+						"elasticloadbalancing:DeregisterInstancesFromLoadBalancer",
+						"elasticloadbalancing:ModifyLoadBalancerAttributes",
+						"elasticloadbalancing:RegisterInstancesWithLoadBalancer",
+						"elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer",
+						"elasticloadbalancing:AddTags",
+						"elasticloadbalancing:CreateListener",
+						"elasticloadbalancing:CreateTargetGroup",
+						"elasticloadbalancing:DeleteListener",
+						"elasticloadbalancing:DeleteTargetGroup",
+						"elasticloadbalancing:DescribeListeners",
+						"elasticloadbalancing:DescribeLoadBalancerPolicies",
+						"elasticloadbalancing:DescribeTargetGroups",
+						"elasticloadbalancing:DescribeTargetHealth",
+						"elasticloadbalancing:ModifyListener",
+						"elasticloadbalancing:ModifyTargetGroup",
+						"elasticloadbalancing:RegisterTargets",
+						"elasticloadbalancing:DeregisterTargets",
+						"elasticloadbalancing:SetLoadBalancerPoliciesOfListener",
+						"iam:CreateServiceLinkedRole",
+						"kms:DescribeKey",
+					},
+					"Effect":   "Allow",
+					"Resource": "*",
+				},
+			},
+		})
+		if err != nil {
+			return err
+		}
+		json0 := string(tmpJSON0)
+
+		// Define IAM policy using JSON object previously defined
+		cpInstancePolicy, err := iam.NewPolicy(ctx, "cp-instance-policy", &iam.PolicyArgs{
+			Name:        pulumi.String("control-plane-instance-policy"),
+			Path:        pulumi.String("/"),
+			Description: pulumi.String("Policy for Kubernetes control plane nodes to interact with AWS API"),
+			Policy:      pulumi.String(json0),
+		})
+		if err != nil {
+			return err
+		}
+		ctx.Export("cpInstancePolicyArn", cpInstancePolicy.Arn)
+
+		// Create a policy for Kubernetes control plane nodes
+		tmpJSON1, err := json.Marshal(map[string]interface{}{
+			"Version": "2012-10-17",
+			"Statement": []map[string]interface{}{
+				map[string]interface{}{
+					"Action": []string{
+						"ec2:DescribeInstances",
+						"ec2:DescribeRegions",
+						"ecr:GetAuthorizationToken",
+						"ecr:BatchCheckLayerAvailability",
+						"ecr:GetDownloadUrlForLayer",
+						"ecr:GetRepositoryPolicy",
+						"ecr:DescribeRepositories",
+						"ecr:ListImages",
+						"ecr:BatchGetImages",
+					},
+					"Effect":   "Allow",
+					"Resource": "*",
+				},
+			},
+		})
+		if err != nil {
+			return err
+		}
+		json1 := string(tmpJSON1)
+
+		// Define IAM policy using JSON object previously defined
+		nodeInstancePolicy, err := iam.NewPolicy(ctx, "node-instance-policy", &iam.PolicyArgs{
+			Name:        pulumi.String("node-instance-policy"),
+			Path:        pulumi.String("/"),
+			Description: pulumi.String("Policy for Kubernetes worker nodes to interact with AWS API"),
+			Policy:      pulumi.String(json1),
+		})
+		if err != nil {
+			return err
+		}
+		ctx.Export("nodeInstancePolicyArn", nodeInstancePolicy.Arn)
+
+		return nil
+	})
+}


### PR DESCRIPTION
This PR adds a Pulumi program that creates AWS IAM entities to allow for Kubernetes integration with AWS via the AWS cloud provider. These entities include a policy for control plane nodes and worker nodes, a role for control plane nodes and worker nodes, and EC2 instance profiles for control plane nodes and worker nodes.